### PR TITLE
fix: command error when attack with no extra command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -145,13 +145,13 @@ const translate = function(i) {
 module.exports = function (text) {
   let resultText = ''
   let result = []
-  const turns = text.split('---\n').filter((i) => !!i)
+  const turns = text.split('---')
   for (let i = 0; i < turns.length; i++) {
     resultText += '第' + (i + 1) + '面\n'
     result.push([])
 
     // 解析命令
-    turns[i].split('\n').filter((c) => !!c).forEach(function(command) {
+    turns[i].split('\n').map(i => i.trim()).filter((c) => !!c).forEach(function(command) {
       const c = /^(\w):(\d),(\d),(\d)$/.exec(command)
       if (!c) {
         toast('错误的指令')

--- a/project.json
+++ b/project.json
@@ -36,5 +36,5 @@
   },
   "scripts": {},
   "versionCode": 1,
-  "versionName": "0.0.9"
+  "versionName": "0.0.10"
 }


### PR DESCRIPTION
过去形如：

```
---
---
```

会解析失败，因为会被自动过滤掉，所以导致了解析问题，现在可以正常用 next turn 来表示不用技能直接攻击了，下面可以表示三面全部不放技能直接攻击。

```
---
---
```